### PR TITLE
Perf: Mock external calls to cut e2e time (Issue #15)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -201,6 +201,29 @@ pytest --cov=src --cov-report=html
 pytest -m "not slow"
 ```
 
+### Network Blocking in Tests
+
+Tests automatically block outbound network calls to ensure fast, deterministic execution. Localhost connections (127.0.0.1) are allowed for Redis, databases, and other local services.
+
+**Control network blocking:**
+- **CI (default)**: Outbound calls blocked automatically
+- **Local (default)**: Outbound calls allowed by default
+- **Override**: Set `TEST_OFFLINE=true` to enable blocking locally, or `TEST_OFFLINE=false` to disable in CI
+
+```bash
+# Run tests with network blocking enabled (local dev)
+TEST_OFFLINE=true pytest
+
+# Run tests allowing network (debugging)
+TEST_OFFLINE=false pytest
+```
+
+**How it works:**
+- Socket-level blocking via `tests/utils/netblock.py`
+- HTTP mocking via `tests/utils/http_fakes.py`
+- Connector tests use stub responses automatically
+- External API calls return fast mock data
+
 ### Writing Tests
 
 - Place tests in `tests/` directory

--- a/docs/perf/README.md
+++ b/docs/perf/README.md
@@ -18,7 +18,11 @@ From `dashboards/ci/slowest-tests.md`:
 - Avoid per-function setup for database connections, API clients
 - Cache computed test data across parametrized runs
 
-**2. Network/External Call Mocking**
+**2. Network/External Call Mocking** ✅ **Issue #15 - Implemented**
+- **Socket-level blocking**: `tests/utils/netblock.py` blocks outbound network at socket layer
+- **HTTP mocking**: `tests/utils/http_fakes.py` provides httpx/requests stubs for connector APIs
+- **TEST_OFFLINE control**: CI blocks by default; local allows override
+- **Expected impact**: ≥20% reduction in e2e suite time by eliminating real API calls
 - Replace real API calls with mocks or VCR cassettes
 - Use in-memory databases instead of Redis/PostgreSQL where feasible
 - Mock file system operations with tmpdir or in-memory structures

--- a/docs/perf/README.md
+++ b/docs/perf/README.md
@@ -1,0 +1,61 @@
+# Performance Optimization Notes
+
+## Sprint 43: e2e Performance Cuts
+
+**Goal**: 20% reduction in full e2e test suite duration
+
+### Current Baseline
+
+From `dashboards/ci/slowest-tests.md`:
+- Total measured duration: 35.94s across top 25 tests
+- Slowest test: `test_full_inbox_drive_sweep_workflow` - 3.45s
+- Target: Reduce to ~29s (20% improvement)
+
+### Optimization Techniques
+
+**1. Fixture Scope Optimization**
+- Use `session` or `module` scope for expensive fixtures
+- Avoid per-function setup for database connections, API clients
+- Cache computed test data across parametrized runs
+
+**2. Network/External Call Mocking**
+- Replace real API calls with mocks or VCR cassettes
+- Use in-memory databases instead of Redis/PostgreSQL where feasible
+- Mock file system operations with tmpdir or in-memory structures
+
+**3. Batch Operations & Parametrization**
+- Chunk large batch operations for better memory usage
+- Use pytest-xdist for parallel test execution
+- Share expensive setup across parametrized test cases
+
+**4. Temporal Dependencies**
+- Replace `time.sleep()` with event polling (shorter timeouts)
+- Use asyncio for concurrent I/O operations
+- Mock time-dependent operations where possible
+
+### Tracking
+
+Performance improvements tracked in:
+- `dashboards/ci/slowest-tests.md` - Updated after each nightly run
+- GitHub Issues #13, #14, #15 - Specific optimization tickets
+- Nightly workflow artifacts - Historical comparison
+
+### Non-Goals
+
+❌ **Not in scope for Sprint 43**:
+- Changing test assertions or reducing coverage
+- Skipping flaky tests without investigation
+- Introducing new test infrastructure (pytest plugins, etc.)
+- Modifying application runtime behavior
+
+### Acceptance Criteria
+
+- [ ] At least 2 of 3 performance issues (#13-#15) resolved
+- [ ] Nightly `slowest-tests.md` shows 20%+ improvement in targeted tests
+- [ ] CI PR suite remains under 90s
+- [ ] All tests still pass with same assertions
+- [ ] No new flaky tests introduced
+
+---
+
+**Reference**: See Sprint 42 (Perf & Telemetry Groundwork) for tooling infrastructure.

--- a/tests/utils/__init__.py
+++ b/tests/utils/__init__.py
@@ -1,0 +1,1 @@
+"""Test utilities for network mocking and test helpers."""

--- a/tests/utils/http_fakes.py
+++ b/tests/utils/http_fakes.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+import json
+
+
+def make_httpx_mock(json_payload: dict, status_code: int = 200):
+    """Create an httpx MockTransport handler if httpx is available."""
+    try:
+        import httpx
+    except ImportError:
+        return None
+
+    def handler(request: httpx.Request) -> httpx.Response:  # type: ignore
+        return httpx.Response(
+            status_code,
+            request=request,
+            content=json.dumps(json_payload).encode("utf-8"),
+            headers={"content-type": "application/json"},
+        )
+
+    return handler
+
+
+def install_httpx_transport(monkeypatch, handler):
+    """Install httpx MockTransport for all httpx clients."""
+    import httpx
+
+    transport = httpx.MockTransport(handler)
+    monkeypatch.setattr(httpx, "Client", lambda *a, **kw: httpx.Client(transport=transport))
+    monkeypatch.setattr(httpx, "AsyncClient", lambda *a, **kw: httpx.AsyncClient(transport=transport))
+
+
+def install_requests_fake(monkeypatch, json_payload: dict, status_code: int = 200):
+    """Install a fake requests.Session.request method for mocking HTTP calls."""
+    import requests
+
+    def _fake(self, method, url, **kwargs):
+        class R:
+            def __init__(self):
+                self.status_code = status_code
+                self._json = json_payload
+                self.text = json.dumps(json_payload)
+
+            def json(self):
+                return self._json
+
+            def raise_for_status(self):
+                if not (200 <= self.status_code < 400):
+                    raise requests.HTTPError(f"{self.status_code}")
+
+        return R()
+
+    monkeypatch.setattr("requests.Session.request", _fake, raising=True)

--- a/tests/utils/netblock.py
+++ b/tests/utils/netblock.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+import os
+import socket
+from contextlib import contextmanager
+
+_ALLOWED = {"127.0.0.1", "localhost", "::1"}
+
+
+class OutboundBlockedSocket(socket.socket):
+    def connect(self, address):
+        host, *_ = address if isinstance(address, tuple) else (address,)
+        try:
+            host_ip = socket.gethostbyname(host) if isinstance(host, str) else host
+        except Exception:
+            host_ip = host
+        if str(host) in _ALLOWED or str(host_ip) in _ALLOWED:
+            return super().connect(address)
+        raise RuntimeError(f"Outbound network blocked to {address}")
+
+
+@contextmanager
+def block_outbound():
+    orig = socket.socket
+    socket.socket = OutboundBlockedSocket  # type: ignore
+    try:
+        yield
+    finally:
+        socket.socket = orig  # type: ignore
+
+
+def should_block_by_default() -> bool:
+    """Determine if outbound network should be blocked by default.
+
+    On CI, block by default. Locally, allow override with TEST_OFFLINE=false.
+    """
+    val = os.getenv("TEST_OFFLINE", "").strip().lower()
+    if "ci" in (os.getenv("GITHUB_ACTIONS") or "").lower():
+        return val not in {"0", "false", "no"}
+    return val in {"1", "true", "yes"}

--- a/tests_e2e/conftest.py
+++ b/tests_e2e/conftest.py
@@ -200,3 +200,36 @@ def http_get_with_retry(host: str, port: int, path: str, max_retries: int = 3, t
 
 # Export helper for use in tests
 __all__ = ["http_get_with_retry"]
+
+
+# Sprint 42: HTTP mocking for external calls (Issue #15)
+
+
+@pytest.fixture(autouse=True)
+def mock_external_http(monkeypatch):
+    """Mock external HTTP calls in e2e tests.
+
+    Automatically applies to all e2e tests to prevent real network calls.
+    Uses httpx MockTransport if available, otherwise falls back to
+    requests monkeypatch.
+
+    Provides stub responses for common connector API patterns.
+    """
+    from tests.utils.http_fakes import install_httpx_transport, install_requests_fake, make_httpx_mock
+
+    # Standard stub response for connector APIs
+    payload = {
+        "ok": True,
+        "items": [],
+        "messages": [],
+        "files": [],
+        "note": "stubbed by e2e mock",
+    }
+
+    handler = make_httpx_mock(payload)
+    if handler is not None:
+        install_httpx_transport(monkeypatch, handler)
+    else:
+        install_requests_fake(monkeypatch, payload)
+
+    yield


### PR DESCRIPTION
### **User description**
## Summary

Implements Issue #15: Mock external API calls in e2e/integration tests to achieve ≥20% speed reduction by blocking real outbound network connections and substituting fast fakes.

**Key Changes:**
- Socket-level outbound blocking via `tests/utils/netblock.py` (allows localhost for Redis/DBs)
- HTTP mocking utilities via `tests/utils/http_fakes.py` (httpx MockTransport + requests fallback)
- Autouse pytest fixtures for test-only network isolation
- TEST_OFFLINE environment variable for CI vs local control (CI blocks by default)

**Zero Runtime Impact:**
- No changes to application code
- No new runtime dependencies
- Tests-only modifications
- Defaults unchanged (local dev still allows network)

**Acceptance Criteria:**
- [x] Network blocking with localhost exemptions
- [x] HTTP mocking for connector APIs
- [x] TEST_OFFLINE control for CI/local override
- [x] Documentation in CONTRIBUTING.md
- [ ] CI verification (awaiting PR checks)
- [ ] ≥20% e2e suite speedup (measured in nightly)

**Commits:**
1. `b8ff2ec` - test(net): add outbound network guard fixture (localhost allowed)
2. `9e37776` - test(http): add pytest fixture for network blocking
3. `6f8f1cc` - test(e2e): stub external connectors with HTTP mocks
4. `41e8b57` - docs(testing): document TEST_OFFLINE toggle and network blocking
5. `9b90ab3` - docs(perf): note external-call mocking and expected speedups

Closes #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Tests, Enhancement


___

### **Description**
- Mock external API calls in e2e tests for speed improvement

- Add socket-level network blocking with localhost exemptions

- Implement TEST_OFFLINE environment variable control

- Create HTTP mocking utilities for connector APIs


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Test Suite"] --> B["Network Blocking"]
  B --> C["Socket Level Block"]
  B --> D["HTTP Mocking"]
  C --> E["Allow Localhost"]
  D --> F["Mock Connector APIs"]
  G["TEST_OFFLINE"] --> B
  H["CI Environment"] --> G
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>conftest.py</strong><dd><code>Add network blocking session fixture</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/conftest.py

<ul><li>Add autouse session fixture for network blocking<br> <li> Implement TEST_OFFLINE environment variable control<br> <li> Block outbound connections while allowing localhost</ul>


</details>


  </td>
  <td><a href="https://github.com/kmabbott81/djp-workflow/pull/17/files#diff-e52e4ddd58b7ef887ab03c04116e676f6280b824ab7469d5d3080e5cba4f2128">+25/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>http_fakes.py</strong><dd><code>HTTP mocking utilities for tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/utils/http_fakes.py

<ul><li>Create httpx MockTransport handler factory<br> <li> Add requests session mocking utilities<br> <li> Implement JSON response stubbing</ul>


</details>


  </td>
  <td><a href="https://github.com/kmabbott81/djp-workflow/pull/17/files#diff-3bc9779d1bcd70ccc806a3e44aaefbd2c3e751b1aeb6bf2dc02f2ed7c24a98de">+53/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>netblock.py</strong><dd><code>Socket-level network blocking utilities</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/utils/netblock.py

<ul><li>Implement socket-level outbound blocking<br> <li> Allow localhost and 127.0.0.1 connections<br> <li> Add TEST_OFFLINE environment detection logic</ul>


</details>


  </td>
  <td><a href="https://github.com/kmabbott81/djp-workflow/pull/17/files#diff-fadd8f8c6a2a398b02c250f72d5079ac61af3d5d7f951cd1a5c749acd69e5205">+40/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>conftest.py</strong><dd><code>Mock external HTTP calls in e2e</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests_e2e/conftest.py

<ul><li>Add autouse fixture for HTTP mocking<br> <li> Mock external connector API calls<br> <li> Provide stub responses for common patterns</ul>


</details>


  </td>
  <td><a href="https://github.com/kmabbott81/djp-workflow/pull/17/files#diff-ab7b4f76f9daa38d79ef7695319cb80063c70c2f6c2130c134f4f78551ad24ea">+33/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Miscellaneous</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>__init__.py</strong><dd><code>Initialize test utils package</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/utils/__init__.py

- Create new test utilities package


</details>


  </td>
  <td><a href="https://github.com/kmabbott81/djp-workflow/pull/17/files#diff-e83d4ce58211688fdd3f132906c3c4ff02b28e14a069c7516df75eeb2478a904">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CONTRIBUTING.md</strong><dd><code>Document network blocking in tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CONTRIBUTING.md

<ul><li>Document network blocking behavior in tests<br> <li> Explain TEST_OFFLINE environment variable usage<br> <li> Add examples for local and CI environments</ul>


</details>


  </td>
  <td><a href="https://github.com/kmabbott81/djp-workflow/pull/17/files#diff-eca12c0a30e25b4b46522ebf89465a03ba72a03f540796c979137931d8f92055">+23/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Performance optimization tracking documentation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/perf/README.md

<ul><li>Create performance optimization tracking document<br> <li> Document Issue #15 implementation details<br> <li> Set Sprint 43 goals and acceptance criteria</ul>


</details>


  </td>
  <td><a href="https://github.com/kmabbott81/djp-workflow/pull/17/files#diff-cbfdb4decc4b937993c4de020db88f1cc643c0428f54c8e638547c02520858e3">+65/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

